### PR TITLE
Feature/ 두통 최종 문진 결과 API

### DIFF
--- a/src/main/java/com/healthier/diagnosis/controller/DiagnosisController.java
+++ b/src/main/java/com/healthier/diagnosis/controller/DiagnosisController.java
@@ -1,7 +1,5 @@
 package com.healthier.diagnosis.controller;
 
-import com.healthier.diagnosis.domain.diagnosis.Diagnosis;
-import com.healthier.diagnosis.repository.DiagnosisRepository;
 import com.healthier.diagnosis.service.DiagnosisService;
 import org.springframework.http.ResponseEntity;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/healthier/diagnosis/controller/HeadacheQuestionController.java
+++ b/src/main/java/com/healthier/diagnosis/controller/HeadacheQuestionController.java
@@ -8,6 +8,9 @@ import com.healthier.diagnosis.dto.headache.commonQuestion.*;
 import com.healthier.diagnosis.dto.headache.painArea.HeadachePainAreaFirstRequest;
 import com.healthier.diagnosis.dto.headache.painArea.HeadachePainAreaNextRequest;
 import com.healthier.diagnosis.dto.headache.painArea.HeadachePainAreaNextResponse;
+import com.healthier.diagnosis.dto.headache.result.HeadacheResultRequest;
+import com.healthier.diagnosis.dto.headache.result.HeadacheResultResponse;
+import com.healthier.diagnosis.service.DiagnosisService;
 import com.healthier.diagnosis.service.HeadacheQuestionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -21,6 +24,7 @@ import java.util.Optional;
 @RestController
 public class HeadacheQuestionController {
     private final HeadacheQuestionService questionService;
+    private final DiagnosisService diagnosisService;
 
     /**
      * 두통 기본 질문
@@ -96,5 +100,13 @@ public class HeadacheQuestionController {
     @PostMapping("/additional-factor")
     public ResultResponse AdditionalFactorResult(@RequestBody @Valid AdditionalFactorResultRequest request) {
         return new ResultResponse(questionService.getAdditionalFactorResult(request.getQuestionId(), request.getAnswerId()));
+    }
+
+    /**
+     * 최종 문진 결과
+     */
+    @PostMapping("/result")
+    public HeadacheResultResponse HeadacheResult(@RequestBody @Valid HeadacheResultRequest request) {
+        return diagnosisService.getHeadacheResult(request);
     }
 }

--- a/src/main/java/com/healthier/diagnosis/domain/diagnosis/Diagnosis.java
+++ b/src/main/java/com/healthier/diagnosis/domain/diagnosis/Diagnosis.java
@@ -3,6 +3,7 @@ package com.healthier.diagnosis.domain.diagnosis;
 import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
 
 import java.util.ArrayList;
 
@@ -14,7 +15,9 @@ import java.util.ArrayList;
 @Document(collection = "diagnosis")
 public class Diagnosis {
     @Id
+    @Field(name = "_id")
     private String id;
+    @Field(name = "id")
     private int newId;
     private String illustration;
     private String h1;
@@ -24,18 +27,37 @@ public class Diagnosis {
     private Explanation explanation;
     private Cause cause;
     private ArrayList<Solution> solutions;
-    private int medicine_flag;
+    @Field(name = "medicine_flag")
+    private int medicineFlag;
     private ArrayList<Medicine> medicines;
     private ArrayList<Treatment> treatments;
-    private String not_sleepdisorder; // DiagnosisId (수면장애 아님)
-    private String sleep_warning; // DiagnosisId (수면습관 경고)
-    private String sleep_caution; // DiagnosisId (수면습관 주의)
-    private String temporary_diagnosis; // DiagnosisId (일시적 불면증)
-    private String short_diagnosis; // DiagnosisId (단기 불면증)
-    private String long_diagnosis; // DiagnosisId (만성 불면증)
+    @Field(name = "banner_illustration")
+    private String bannerIllustration;
+
+    /**
+     * category : 수면장애
+     */
+    @Field(name = "not_sleepdisorder")
+    private String notSleepdisorder; // DiagnosisId (수면장애 아님)
+    @Field(name = "sleep_warning")
+    private String sleepWarning; // DiagnosisId (수면습관 경고)
+    @Field(name = "sleep_caution")
+    private String sleepCaution; // DiagnosisId (수면습관 주의)
+    @Field(name = "temporary_diagnosis")
+    private String temporaryDiagnosis; // DiagnosisId (일시적 불면증)
+    @Field(name = "short_diagnosis")
+    private String shortDiagnosis; // DiagnosisId (단기 불면증)
+    @Field(name = "long_diagnosis")
+    private String longDiagnosis; // DiagnosisId (만성 불면증)
+
+    /**
+     * category : 두통
+     */
     private String MOH; // DiagnosisId (약물과용 두통)
-    private String mild_headache; // DiagnosisId (경미한 두통)
-    private String warning_headache; // DiagnosisId (중증 두통)
-    private String severe_headache; // DiagnosisId (만성 두통)
-    private String banner_illustration;
+    @Field(name = "mild_headache")
+    private String mildHeadache; // DiagnosisId (경미한 두통)
+    @Field(name = "warning_headache")
+    private String warningHeadache; // DiagnosisId (중증 두통)
+    @Field(name = "severe_headache")
+    private String severeHeadache; // DiagnosisId (만성 두통)
 }

--- a/src/main/java/com/healthier/diagnosis/domain/diagnosis/Diagnosis.java
+++ b/src/main/java/com/healthier/diagnosis/domain/diagnosis/Diagnosis.java
@@ -1,6 +1,7 @@
 package com.healthier.diagnosis.domain.diagnosis;
 
 import lombok.*;
+import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
@@ -14,7 +15,8 @@ import java.util.ArrayList;
 @Document(collection = "diagnosis")
 public class Diagnosis {
     @Id
-    private String id;
+    private ObjectId _id;
+    private int id;
     private String illustration;
     private String h1;
     private String title;

--- a/src/main/java/com/healthier/diagnosis/domain/diagnosis/Diagnosis.java
+++ b/src/main/java/com/healthier/diagnosis/domain/diagnosis/Diagnosis.java
@@ -1,7 +1,6 @@
 package com.healthier.diagnosis.domain.diagnosis;
 
 import lombok.*;
-import org.bson.types.ObjectId;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
@@ -15,8 +14,8 @@ import java.util.ArrayList;
 @Document(collection = "diagnosis")
 public class Diagnosis {
     @Id
-    private ObjectId _id;
-    private int id;
+    private String id;
+    private int newId;
     private String illustration;
     private String h1;
     private String title;

--- a/src/main/java/com/healthier/diagnosis/domain/log/Log.java
+++ b/src/main/java/com/healthier/diagnosis/domain/log/Log.java
@@ -1,5 +1,6 @@
-package com.healthier.diagnosis.domain.user;
+package com.healthier.diagnosis.domain.log;
 
+import com.healthier.diagnosis.domain.user.Track;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.mongodb.core.mapping.Document;

--- a/src/main/java/com/healthier/diagnosis/dto/headache/ResultDto.java
+++ b/src/main/java/com/healthier/diagnosis/dto/headache/ResultDto.java
@@ -1,18 +1,21 @@
 package com.healthier.diagnosis.dto.headache;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Data;
 import lombok.Getter;
 
 @Data
 @Getter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class ResultDto {
-    private int result_id;
+    private int resultId;
     private String result;
 
     protected ResultDto() {}
 
-    public ResultDto(int result_id, String result) {
-        this.result_id = result_id;
+    public ResultDto(int resultId, String result) {
+        this.resultId = resultId;
         this.result = result;
     }
 }

--- a/src/main/java/com/healthier/diagnosis/dto/headache/result/HeadacheResult.java
+++ b/src/main/java/com/healthier/diagnosis/dto/headache/result/HeadacheResult.java
@@ -1,0 +1,23 @@
+package com.healthier.diagnosis.dto.headache.result;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class HeadacheResult {
+    private List<HeadacheResultDto> likely;
+    private List<HeadacheResultDto> suspicious;
+    private List<HeadacheResultDto> predicted;
+
+    protected HeadacheResult() {}
+
+    public HeadacheResult(List<HeadacheResultDto> likely, List<HeadacheResultDto> suspicious, List<HeadacheResultDto> predicted) {
+        this.likely = likely;
+        this.suspicious = suspicious;
+        this.predicted  = predicted;
+    }
+}

--- a/src/main/java/com/healthier/diagnosis/dto/headache/result/HeadacheResultDto.java
+++ b/src/main/java/com/healthier/diagnosis/dto/headache/result/HeadacheResultDto.java
@@ -1,0 +1,20 @@
+package com.healthier.diagnosis.dto.headache.result;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class HeadacheResultDto {
+    private int id;
+    private String content;
+    private String bannerImg;
+
+    protected HeadacheResultDto() {}
+    public HeadacheResultDto(int id, String content, String bannerImg) {
+        this.id = id;
+        this.content = content;
+        this.bannerImg = bannerImg;
+    }
+
+}

--- a/src/main/java/com/healthier/diagnosis/dto/headache/result/HeadacheResultRequest.java
+++ b/src/main/java/com/healthier/diagnosis/dto/headache/result/HeadacheResultRequest.java
@@ -1,0 +1,34 @@
+package com.healthier.diagnosis.dto.headache.result;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.healthier.diagnosis.dto.headache.ResultDto;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class HeadacheResultRequest {
+
+    private String gender;
+    private int birthYear;
+    private List<Integer> interests;
+    private List<Track> tracks;         // 질문/답변
+    private List<ResultDto> results;    // 문진결과
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public static class Track {
+        private int questionId;
+        private List<Integer> answerId;
+    }
+}

--- a/src/main/java/com/healthier/diagnosis/dto/headache/result/HeadacheResultResponse.java
+++ b/src/main/java/com/healthier/diagnosis/dto/headache/result/HeadacheResultResponse.java
@@ -1,0 +1,16 @@
+package com.healthier.diagnosis.dto.headache.result;
+
+import lombok.Data;
+
+@Data
+public class HeadacheResultResponse {
+    private int type;
+    private HeadacheResult results;
+
+    protected HeadacheResultResponse() { }
+
+    public HeadacheResultResponse(int type, HeadacheResult results) {
+        this.type = type;
+        this.results = results;
+    }
+}

--- a/src/main/java/com/healthier/diagnosis/repository/DiagnosisLogRepository.java
+++ b/src/main/java/com/healthier/diagnosis/repository/DiagnosisLogRepository.java
@@ -1,8 +1,10 @@
 package com.healthier.diagnosis.repository;
 
-import com.healthier.diagnosis.domain.user.Log;
+import com.healthier.diagnosis.domain.log.Log;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface DiagnosisLogRepository extends MongoRepository<Log, String> {
 
 }

--- a/src/main/java/com/healthier/diagnosis/repository/DiagnosisRepository.java
+++ b/src/main/java/com/healthier/diagnosis/repository/DiagnosisRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 @Repository
 public interface DiagnosisRepository extends MongoRepository<Diagnosis, String> {
     Optional<Diagnosis> findById(@Param("id") String id);
+    Optional<Diagnosis> findByNewId(@Param("newId") int id);
 }

--- a/src/main/java/com/healthier/diagnosis/service/DiagnosisService.java
+++ b/src/main/java/com/healthier/diagnosis/service/DiagnosisService.java
@@ -1,19 +1,45 @@
 package com.healthier.diagnosis.service;
 
 import com.healthier.diagnosis.domain.diagnosis.Diagnosis;
+import com.healthier.diagnosis.domain.log.Log;
+import com.healthier.diagnosis.domain.user.Track;
 import com.healthier.diagnosis.dto.DiagnosisResponseDto;
+import com.healthier.diagnosis.dto.headache.ResultDto;
+import com.healthier.diagnosis.dto.headache.result.HeadacheResult;
+import com.healthier.diagnosis.dto.headache.result.HeadacheResultDto;
+import com.healthier.diagnosis.dto.headache.result.HeadacheResultRequest;
+import com.healthier.diagnosis.dto.headache.result.HeadacheResultResponse;
 import com.healthier.diagnosis.exception.CustomException;
 import com.healthier.diagnosis.exception.ErrorCode;
+import com.healthier.diagnosis.repository.DiagnosisLogRepository;
 import com.healthier.diagnosis.repository.DiagnosisRepository;
 import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
 public class DiagnosisService {
     private final DiagnosisRepository diagnosisRepository;
+
+    private final DiagnosisLogRepository logRepository;
+
+    ModelMapper modelMapper = new ModelMapper();
+
+    private static final Boolean LOG_FLAG = false;
+
+    private static final int MEDICATION_OVER_USE_ID = 1025;
+    private static final int TENSION_HEADACHE_ID = 1015;
+    private static final int[] PRIMARY_HEADACHE_ID = new int[]{1002, 1003, 1015, 1019};
+
 
     /**
      * 진단결과 조회
@@ -31,24 +57,21 @@ public class DiagnosisService {
     /**
      * 수면장애 : 수면장애가 아닌 경우 수면위생점수로 진단
      */
-    public String findSleepdisorderWithSHI(String id, int SHI)
-    {
+    public String findSleepdisorderWithSHI(String id, int SHI) {
         Diagnosis diagnosis = diagnosisRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.DIAGNOSIS_NOT_FOUND));
 
         String result_diagnosis_id;
 
         if (SHI < 0 || SHI > 17) {
-        throw new CustomException(ErrorCode.RANGE_NOT_SATISFIABLE);
-         }
-        if (SHI <= 6){ // 수면 장애 아님
-            result_diagnosis_id = diagnosis.getNot_sleepdisorder();
+            throw new CustomException(ErrorCode.RANGE_NOT_SATISFIABLE);
         }
-        else if(SHI >= 11) { // 수면습관 경고
-            result_diagnosis_id = diagnosis.getSleep_warning();
-        }
-        else { // 수면습관 주의
-            result_diagnosis_id = diagnosis.getSleep_caution();
+        if (SHI <= 6) { // 수면 장애 아님
+            result_diagnosis_id = diagnosis.getNotSleepdisorder();
+        } else if (SHI >= 11) { // 수면습관 경고
+            result_diagnosis_id = diagnosis.getSleepWarning();
+        } else { // 수면습관 주의
+            result_diagnosis_id = diagnosis.getSleepCaution();
         }
 
         return result_diagnosis_id;
@@ -64,14 +87,14 @@ public class DiagnosisService {
         String result_diagnosis_id;
 
         if (period == 1) { // temporary
-            result_diagnosis_id = diagnosisRepository.findById(diagnosis.getTemporary_diagnosis())
+            result_diagnosis_id = diagnosisRepository.findById(diagnosis.getTemporaryDiagnosis())
                     .orElseThrow(() -> new CustomException(ErrorCode.DIAGNOSIS_NOT_FOUND)).getId();
         } else if (period > 1 && period < 3) { // short
-            result_diagnosis_id = diagnosisRepository.findById(diagnosis.getShort_diagnosis())
+            result_diagnosis_id = diagnosisRepository.findById(diagnosis.getShortDiagnosis())
                     .orElseThrow(() -> new CustomException(ErrorCode.DIAGNOSIS_NOT_FOUND)).getId();
 
         } else { // long
-            result_diagnosis_id = diagnosisRepository.findById(diagnosis.getLong_diagnosis())
+            result_diagnosis_id = diagnosisRepository.findById(diagnosis.getLongDiagnosis())
                     .orElseThrow(() -> new CustomException(ErrorCode.DIAGNOSIS_NOT_FOUND)).getId();
         }
 
@@ -85,23 +108,138 @@ public class DiagnosisService {
                                                int is_taking_medicine,
                                                int pain_level,
                                                int period,
-                                               int cycle)
-    {
+                                               int cycle) {
         Diagnosis diagnosis = diagnosisRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.DIAGNOSIS_NOT_FOUND));
 
         if (is_taking_medicine == 0) { // 약물과용 두통
             return diagnosis.getMOH();
-        }
-        else if ( ((period == 2) | (period == 3)) & (cycle == 0)) { // 만성
-            return diagnosis.getSevere_headache();
-        }
-        else if ((pain_level == 1 ) | (pain_level == 2)) { // 경미
-            return diagnosis.getMild_headache();
-        }
-        else { // 주의
-            return diagnosis.getWarning_headache();
+        } else if (((period == 2) | (period == 3)) & (cycle == 0)) { // 만성
+            return diagnosis.getSevereHeadache();
+        } else if ((pain_level == 1) | (pain_level == 2)) { // 경미
+            return diagnosis.getMildHeadache();
+        } else { // 주의
+            return diagnosis.getWarningHeadache();
         }
 
     }
+
+    /**
+     * 두통 : 최종 문진 결과
+     */
+    public HeadacheResultResponse getHeadacheResult(HeadacheResultRequest request) {
+
+
+        /**
+         * TODO: Headache log : 기존의 Log 와 차이점
+         * 1. 진단 결과가 여러개 도출
+         * 2. category = headache 추가 예정 ( 후에 data 분석을 위해서 ! )
+         */
+
+        // 전체 Log 남기기
+        if (LOG_FLAG) {
+            logRepository.save(
+                    Log.builder()
+                            .gender(request.getGender())
+                            .is_created(LocalDateTime.now())
+                            .birthyear(request.getBirthYear())
+                            .interests(request.getInterests())
+                            .tracks(request.getTracks()
+                                    .stream()
+                                    .map(c -> modelMapper.map(c, Track.class))
+                                    .collect(Collectors.toList()))
+                            .build()
+            );
+        }
+
+        // 우선순위 정렬
+        List<ResultDto> results = request.getResults();
+
+        return getHeadacheResultPriority(results);
+    }
+
+    /**
+     * 두통 : 최종 문진 결과 우선순위
+     *
+     * 1) 일차성두통 O and 눈/뒷목/뒷머리/턱/코주위/얼굴피부 결과 O
+     * likely. 가능성 높은 질환이에요 (일차성 두통)
+     * suspicious. 다음질환도 의심되어요 (부위별 진단 + 약물 과용으로 인한 두통)
+     *
+     * 2) 일차성두통 O and 눈/뒷목/뒷머리/턱/코주위/얼굴피부 결과 X
+     * likely. 가장 가능성 높은 질환이에요 (일차성 두통)
+     * suspicious. 다음질환도 의심되어요 (부위별 진단 + 약물 과용으로 인한 두통)
+     *
+     * 3) 일차성두통 X and 눈/뒷목/뒷머리/턱/코주위/얼굴피부 결과 X
+     * likely. 가능성이 높은 질환이에요 (긴장성 두통)
+     * suspicious. 다음질환도 의심되어요 (+ 약물 과용으로 인한 두통)
+     *
+     * 4) 일차성두통 X and 눈/뒷목/뒷머리/턱/코주위/얼굴피부 결과 O
+     * predicted. 예상질환이에요 (부위별 진단)
+     * suspicious. 다음질환도 의심되어요 (+ 약물 과용으로 인한 두통)
+     *
+     */
+
+    public HeadacheResultResponse getHeadacheResultPriority(List<ResultDto> resultList) {
+
+        List<HeadacheResultDto> likely = new ArrayList<>(); // 가능성이 높은 질환이에요
+        List<HeadacheResultDto> predicted = new ArrayList<>(); // 예상질환이에요
+        List<HeadacheResultDto> suspicious = new ArrayList<>(); // 다음질환도 의심되어요
+
+
+
+        boolean flag1 = false; // 일차성 두통 존재 flag
+        boolean flag2 = false; // 일차성 두통 존재 flag
+
+        for (ResultDto result : resultList) {
+            Diagnosis diagnosis = diagnosisRepository.findByNewId(result.getResultId()).get();
+            HeadacheResultDto resultDto = new HeadacheResultDto(result.getResultId(), result.getResult(), diagnosis.getBannerIllustration());
+
+            if (!flag2) {
+                for (int id : PRIMARY_HEADACHE_ID) {
+                    if (result.getResultId() == id) {
+                        flag1 = true;
+                        flag2 = true;
+                        break;
+                    }
+                }
+            }
+
+            if (flag1) {
+                likely.add(resultDto); // likely
+                flag1 = false;
+            }
+            else if (result.getResultId() == MEDICATION_OVER_USE_ID) {
+                // 약물 과용으로 인한 두통
+                predicted.add(resultDto);
+            } else {
+                // 부위별 결과
+                suspicious.add(resultDto);
+            }
+        }
+
+        if (suspicious.size() == 0) { suspicious = null; }
+        if (predicted.size() == 0) { predicted = null; }
+
+        if (flag2) {
+            // 1) 일차성두통 O and 눈/뒷목/뒷머리/턱/코주위/얼굴피부 결과 O
+            // 2) 일차성두통 O and 눈/뒷목/뒷머리/턱/코주위/얼굴피부 결과 X
+
+            return new HeadacheResultResponse(1, new HeadacheResult(likely, suspicious, predicted));
+
+        } else if (suspicious == null) {
+            // 3) 일차성두통 X and 눈/뒷목/뒷머리/턱/코주위/얼굴피부 결과 X
+
+            Diagnosis diagnosis = diagnosisRepository.findByNewId(TENSION_HEADACHE_ID).get(); // likely = 긴장성 두통
+            HeadacheResultDto resultDto = new HeadacheResultDto(diagnosis.getNewId(), diagnosis.getTitle(), diagnosis.getBannerIllustration());
+            likely.add(resultDto);
+
+            return new HeadacheResultResponse(3, new HeadacheResult(likely, null, predicted));
+
+        } else {
+            // 4) 일차성두통 X and 눈/뒷목/뒷머리/턱/코주위/얼굴피부 결과 O
+
+            return new HeadacheResultResponse(4, new HeadacheResult(null, suspicious, predicted));
+        }
+    }
+
 }

--- a/src/main/java/com/healthier/diagnosis/service/QuestionService.java
+++ b/src/main/java/com/healthier/diagnosis/service/QuestionService.java
@@ -2,7 +2,7 @@ package com.healthier.diagnosis.service;
 
 import com.healthier.diagnosis.domain.question.Answer;
 import com.healthier.diagnosis.domain.question.Question;
-import com.healthier.diagnosis.domain.user.Log;
+import com.healthier.diagnosis.domain.log.Log;
 import com.healthier.diagnosis.domain.user.Track;
 import com.healthier.diagnosis.dto.*;
 import com.healthier.diagnosis.exception.CustomException;

--- a/src/main/java/com/healthier/diagnosis/service/UserService.java
+++ b/src/main/java/com/healthier/diagnosis/service/UserService.java
@@ -107,7 +107,7 @@ public class UserService {
 
             User.ResponseRecord response_record = User.ResponseRecord.builder()
                     .Record(record)
-                    .banner_illustration(diagnosis.getBanner_illustration())
+                    .banner_illustration(diagnosis.getBannerIllustration())
                     .build();
 
             response_records.add(response_record);
@@ -158,7 +158,7 @@ public class UserService {
 
             User.ResponseRecord response_record = User.ResponseRecord.builder()
                     .Record(my_record)
-                    .banner_illustration(my_diagnosis.getBanner_illustration())
+                    .banner_illustration(my_diagnosis.getBannerIllustration())
                     .build();
 
             response_records.add(response_record);

--- a/src/test/java/com/healthier/diagnosis/controller/HeadacheQuestionControllerTest.java
+++ b/src/test/java/com/healthier/diagnosis/controller/HeadacheQuestionControllerTest.java
@@ -1,11 +1,11 @@
 package com.healthier.diagnosis.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.healthier.diagnosis.dto.headache.AdditionalFactorResultRequest;
-import com.healthier.diagnosis.dto.headache.QuestionResponse;
+import com.healthier.diagnosis.dto.headache.ResultDto;
 import com.healthier.diagnosis.dto.headache.painArea.HeadachePainAreaFirstRequest;
 import com.healthier.diagnosis.dto.headache.painArea.HeadachePainAreaNextRequest;
+import com.healthier.diagnosis.dto.headache.result.HeadacheResultRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,7 +18,10 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -92,6 +95,37 @@ class HeadacheQuestionControllerTest {
                         .content(
                                 objectMapper.writeValueAsString(new AdditionalFactorResultRequest(601, new int [] {2, 3} )
                                 )))
+                .andExpect(result -> status().isOk());
+    }
+
+    @DisplayName("API : 최종 문진 결과")
+    @Test
+    public void headacheResult() throws Exception {
+
+        List<ResultDto> results = new ArrayList<>();
+
+        results.add(new ResultDto(1002, "전조증상이 있는 편두통"));
+        results.add(new ResultDto(1022, "대후두 신경통"));
+        results.add(new ResultDto(1025, "약물 과용 두통"));
+
+        HeadacheResultRequest request = HeadacheResultRequest.builder()
+                .gender("f")
+                .birthYear(2000)
+                .interests(Arrays.asList(0))
+                .tracks(Arrays.asList(
+                            HeadacheResultRequest.Track.builder().questionId(412).answerId(Arrays.asList(1)).build(),
+                            HeadacheResultRequest.Track.builder().questionId(412).answerId(Arrays.asList(0)).build(),
+                            HeadacheResultRequest.Track.builder().questionId(413).answerId(Arrays.asList(1)).build(),
+                            HeadacheResultRequest.Track.builder().questionId(414).answerId(Arrays.asList(0)).build(),
+                            HeadacheResultRequest.Track.builder().questionId(415).answerId(Arrays.asList(0)).build()
+                        )
+                )
+                .results(results)
+                .build();
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v2/diagnose/headache/result").contentType(MediaType.APPLICATION_JSON)
+                .content(
+                        objectMapper.writeValueAsString(request)))
                 .andExpect(result -> status().isOk());
     }
 }

--- a/src/test/java/com/healthier/diagnosis/service/DiagnosisServiceTest.java
+++ b/src/test/java/com/healthier/diagnosis/service/DiagnosisServiceTest.java
@@ -1,11 +1,17 @@
 package com.healthier.diagnosis.service;
 
 import com.healthier.diagnosis.dto.DiagnosisResponseDto;
+import com.healthier.diagnosis.dto.headache.ResultDto;
+import com.healthier.diagnosis.dto.headache.result.HeadacheResultResponse;
 import com.healthier.diagnosis.repository.DiagnosisRepository;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -46,5 +52,56 @@ class DiagnosisServiceTest {
 
         //then
         assertThat(diagnosis.getDiagnosticResult().getTitle()).isEqualTo("단기 불면증");
+    }
+
+    @DisplayName("두통 최종 문진 결과 우선순위 조회 - type 1")
+    @Test
+    public void getHeadacheResultPriorityTest1() throws Exception {
+        //given
+        List<ResultDto> results = new ArrayList<>();
+
+        results.add(new ResultDto(1002, "전조증상이 있는 편두통"));
+        results.add(new ResultDto(1022, "대후두 신경통"));
+
+        //when
+
+        HeadacheResultResponse resultPriority = diagnosisService.getHeadacheResultPriority(results);
+
+        //then
+        Assertions.assertThat(resultPriority.getResults().getLikely().get(0).getContent()).isEqualTo("전조증상이 있는 편두통");
+        Assertions.assertThat(resultPriority.getResults().getSuspicious().get(0).getContent()).isEqualTo("대후두 신경통");
+        Assertions.assertThat(resultPriority.getResults().getPredicted()).isEqualTo(null);
+    }
+
+    @DisplayName("두통 최종 문진 결과 우선순위 조회 - type 3")
+    @Test
+    public void getHeadacheResultPriorityTest3() throws Exception {
+        //given
+        List<ResultDto> results = new ArrayList<>();
+
+        //when
+
+        HeadacheResultResponse resultPriority = diagnosisService.getHeadacheResultPriority(results);
+
+        //thens
+        Assertions.assertThat(resultPriority.getResults().getLikely().get(0).getContent()).isEqualTo("긴장성 두통");
+        Assertions.assertThat(resultPriority.getResults().getPredicted()).isEqualTo(null);
+    }
+
+    @DisplayName("두통 최종 문진 결과 우선순위 조회 - type 4")
+    @Test
+    public void getHeadacheResultPriorityTest4() throws Exception {
+        //given
+        List<ResultDto> results = new ArrayList<>();
+        results.add(new ResultDto(1022, "대후두 신경통"));
+        results.add(new ResultDto(1025, "약물 과용으로 인한 두통"));
+
+        //when
+
+        HeadacheResultResponse resultPriority = diagnosisService.getHeadacheResultPriority(results);
+
+        //thens
+        Assertions.assertThat(resultPriority.getResults().getSuspicious().get(0).getContent()).isEqualTo("대후두 신경통");
+        Assertions.assertThat(resultPriority.getResults().getPredicted().get(0).getContent()).isEqualTo("약물 과용으로 인한 두통");
     }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feature/11-result -> dev

### 변경 사항
- **두통 최종 문진 결과 API**를 추가했습니다. 
- 해당 API에 대한 service test, controller test 를 추가했습니다.
- service/HeadacheDiagnosisService : 두통 최종 문진 결과, 문진 결과 우선순위 함수를 나누어 작성했습니다.
    - 두통 최종 문진 결과 함수 :1) 로그 남기기 2) 문진 결과 우선순위 함수 호출
    
- controller/HeadacheDiagnosisController : 두통 최종 문진 결과 API
- dto/headache/HeadacheResultResponse : 두통 최종 문진 결과 Response 입니다.
- dto/headache/HeadacheResultRequest : 두통 최종 문진 결과 Request 입니다.
- dto/headache/HeadacheResultDto : 두통 최종 문진 결과 Request 에 사용되는 dto 입니다.
    - HeadacheResultResponse 와 달리, 배너 일러스트 url 이 포함

- 리팩토링
    - Diagnosis 도메인에 int id 필드를 추가했습니다. (기존 string _id 랑 구분)
    
    - 사용하지 않는 import 문들을 삭제했습니다.
    - camel 표기법을 사용하기 위해 필드를 수정하였습니다.
    - user/Log.java 파일을 log/Log.java 로 디렉토리를 변경했습니다. 