### PR TITLE
Feature/ 특정 통증 부위 다음 질문 API (눈, 눈 주위 로직 추가)

### DIFF
--- a/src/main/java/com/healthier/diagnosis/dto/headache/painArea/HeadachePainAreaNextResponse.java
+++ b/src/main/java/com/healthier/diagnosis/dto/headache/painArea/HeadachePainAreaNextResponse.java
@@ -18,8 +18,8 @@ public class HeadachePainAreaNextResponse {
     protected HeadachePainAreaNextResponse() {}
 
     //1) 생성자 : 다음 질문 반환
-    public HeadachePainAreaNextResponse(Question question) {
-        type = 1;
+    public HeadachePainAreaNextResponse(int type, Question question) {
+        this.type = type;
         questions.add(new QuestionDto(question));
     }
 

--- a/src/main/java/com/healthier/diagnosis/service/HeadacheQuestionService.java
+++ b/src/main/java/com/healthier/diagnosis/service/HeadacheQuestionService.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class HeadacheQuestionService {
     private final HeadacheQuestionRepository questionRepository;
+    private static final int [] PAIN_LEVEL_CHECK_QUESTION = { 404, 405, 406 };
 
     /**
      * 두통 기본 질문 조회
@@ -230,6 +231,7 @@ public class HeadacheQuestionService {
      * 특정 통증 부위 다음 질문 조회
      * type 1 : 다음 질문
      * type 2 : 진단 결과 안내
+     * type 3 : ID - 404, 405, 406 (통증 수치 질문) 반환
      */
     public HeadachePainAreaNextResponse findPainAreaNextQuestion(int questionId, int answerId) {
         Optional<Question> question = questionRepository.findById(questionId);
@@ -238,10 +240,18 @@ public class HeadacheQuestionService {
         //다음 질문이 존재할 때
         if (!answer.isDecisive()) {
             int nextQuestionId = answer.getNextQuestionId(); //다음 질문 id
-            return new HeadachePainAreaNextResponse(questionRepository.findById(nextQuestionId).get());
+
+            // type 3: 통증 수치 질문
+            if (Arrays.stream(PAIN_LEVEL_CHECK_QUESTION).anyMatch(i -> i == nextQuestionId)) {
+                return new HeadachePainAreaNextResponse(3, questionRepository.findById(nextQuestionId).get());
+            }
+            // type 1: 일반 질문
+            else {
+                return new HeadachePainAreaNextResponse(1, questionRepository.findById(nextQuestionId).get());
+            }
         }
 
-        //다음 질문이 존재하지 않을 때
+        // type 2: 진단 결과 안내
         else {
             return new HeadachePainAreaNextResponse(answer.getResultId(), answer.getResult());
         }

--- a/src/test/java/com/healthier/diagnosis/service/HeadacheQuestionServiceTest.java
+++ b/src/test/java/com/healthier/diagnosis/service/HeadacheQuestionServiceTest.java
@@ -78,6 +78,21 @@ class HeadacheQuestionServiceTest {
         Assertions.assertThat(next.getResult().getResult()).isEqualTo("삼차신경통");
     }
 
+    @DisplayName("특정 통증 부위 다음 질문 - Type 3: 통증 수치 질문")
+    @Test
+    public void findPainAreaNextQuestionPainLevel() throws Exception {
+        //given
+        int questionId = 403;
+        int answerId = 0;
+
+        //when
+        HeadachePainAreaNextResponse next = questionService.findPainAreaNextQuestion(questionId, answerId);
+
+        //then
+        Assertions.assertThat(next.getType()).isEqualTo(3);
+        Assertions.assertThat(next.getQuestions().get(0).getQuestion()).isEqualTo("통증 수치가 5 이상 인가요?");
+    }
+
     @DisplayName("추가적인 악화 요인 질문")
     @Test
     public void findAdditionalFactorQuestion() throws Exception {
@@ -101,8 +116,9 @@ class HeadacheQuestionServiceTest {
         ResultDto resultDto1 = questionService.getAdditionalFactorResult(questionId, answerId1);
         ResultDto resultDto2 = questionService.getAdditionalFactorResult(questionId, answerId2);
 
+        System.out.println(resultDto1);
         //then
-        Assertions.assertThat(resultDto1.getResult()).isEqualTo("약물 과용으로 인한 두통");
+        Assertions.assertThat(resultDto1.getResult()).isEqualTo("약물 과용 두통");
         Assertions.assertThat(resultDto2).isEqualTo(null);
     }
 }

--- a/src/test/java/com/healthier/diagnosis/service/QuestionServiceTest.java
+++ b/src/test/java/com/healthier/diagnosis/service/QuestionServiceTest.java
@@ -1,6 +1,5 @@
 package com.healthier.diagnosis.service;
 
-import com.healthier.diagnosis.domain.question.Question;
 import com.healthier.diagnosis.domain.user.Track;
 import com.healthier.diagnosis.dto.*;
 import com.healthier.diagnosis.repository.QuestionRepository;
@@ -8,14 +7,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.mongodb.core.aggregation.ArrayOperators;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
-import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 class QuestionServiceTest {
@@ -232,15 +227,15 @@ class QuestionServiceTest {
     }
 
     // 두통 초기 질문
-    @DisplayName("두통 초기 질문")
-    @Test
-    void getHeadacheFirstQuestion(){
-        // when
-        QuestionDto first_question = questionService.findFirstQuestion("headache");
-
-        // then
-        assertThat(first_question.getQuestion()).isEqualTo("언제부터 통증이 시작되었나요?");
-    }
+//    @DisplayName("두통 초기 질문")
+//    @Test
+//    void getHeadacheFirstQuestion(){
+//        // when
+//        QuestionDto first_question = questionService.findFirstQuestion("headache");
+//
+//        // then
+//        assertThat(first_question.getQuestion()).isEqualTo("언제부터 통증이 시작되었나요?");
+//    }
 
     // 두통 마지막 초기 질문 응답
     @DisplayName("두통 마지막 초기 질문 응답")


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feature/13-pain-area-next -> dev

### 변경 사항
- **특정 통증 부위 다음 질문 API**에 눈, 눈 주위 로직 테스트 및 기능 추가했습니다.  
- 눈, 눈 주위 로직에서 <통증 수치 질문> 과 관련한 예외 처리를 추가했습니다.
- 이전 두통 로직 API (v1) 에서 사용한 테스트를 주석처리했습니다.
- **특정 통증 부위 다음 질문 API**의 DTO Response 생성자를 수정했습니다.