### PR TITLE
Feature/일차성 두통 감별로직 공통질문 API 추가

### DIFF
--- a/src/main/java/com/healthier/diagnosis/controller/HeadacheQuestionController.java
+++ b/src/main/java/com/healthier/diagnosis/controller/HeadacheQuestionController.java
@@ -70,7 +70,7 @@ public class HeadacheQuestionController {
      * 일차성 두통 공통 질문 응답
      */
     @PostMapping("/primary-headache/next")
-    public PrimaryHeadacheNextResponse PrimaryHeadacheNextQuestion(@RequestBody @Valid QnARequest request) {
+    public PrimaryHeadacheNextResponse PrimaryHeadacheNextQuestion(@RequestBody @Valid PrimaryHeadacheNextRequest request) {
         return questionService.findPrimaryHeadacheNextQuestion(request);
     }
 

--- a/src/main/java/com/healthier/diagnosis/controller/HeadacheQuestionController.java
+++ b/src/main/java/com/healthier/diagnosis/controller/HeadacheQuestionController.java
@@ -51,6 +51,14 @@ public class HeadacheQuestionController {
     }
 
     /**
+     * 일차성 두통 감별로직 공통질문
+     */
+    @GetMapping("/primary-headache")
+    public QuestionResponse GetPrimaryHeadacheQuestion() {
+        return new QuestionResponse(questionService.getPrimaryHeadacheQuestion());
+    }
+
+    /**
      * 일차성 두통 공통 질문 결과
      */
     @PostMapping("/primary-headache")

--- a/src/main/java/com/healthier/diagnosis/dto/headache/commonQuestion/PrimaryHeadacheNextRequest.java
+++ b/src/main/java/com/healthier/diagnosis/dto/headache/commonQuestion/PrimaryHeadacheNextRequest.java
@@ -1,0 +1,19 @@
+package com.healthier.diagnosis.dto.headache.commonQuestion;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class PrimaryHeadacheNextRequest {
+    private int questionId;
+    private int answerId;
+    private int unknownEmergency;
+}

--- a/src/main/java/com/healthier/diagnosis/dto/headache/painArea/HeadachePainAreaNextResponse.java
+++ b/src/main/java/com/healthier/diagnosis/dto/headache/painArea/HeadachePainAreaNextResponse.java
@@ -13,6 +13,8 @@ public class HeadachePainAreaNextResponse {
     private int type;
     private List<QuestionDto> questions = new ArrayList<>();
     ResultDto result;
+    private String message;
+    private int unknownEmergency;
 
     //생성자
     protected HeadachePainAreaNextResponse() {}
@@ -27,5 +29,12 @@ public class HeadachePainAreaNextResponse {
     public HeadachePainAreaNextResponse(int resultId, String result) {
         type = 2;
         this.result = new ResultDto(resultId, result);
+    }
+
+    //3) 생성자 : 일차성 두통 감별로직 공통질문 요청 + 예외 가능성 변수
+    public HeadachePainAreaNextResponse(int type, String message, int unknownEmergency) {
+        this.type = type;
+        this.message = message;
+        this.unknownEmergency = unknownEmergency;
     }
 }

--- a/src/main/java/com/healthier/diagnosis/service/HeadacheQuestionService.java
+++ b/src/main/java/com/healthier/diagnosis/service/HeadacheQuestionService.java
@@ -135,11 +135,14 @@ public class HeadacheQuestionService {
     /**
      * 일차성 두통 질문 응답
      */
-    public PrimaryHeadacheNextResponse findPrimaryHeadacheNextQuestion(QnARequest request) {
+    public PrimaryHeadacheNextResponse findPrimaryHeadacheNextQuestion(PrimaryHeadacheNextRequest request) {
         Question question = questionRepository.findById(request.getQuestionId()).get();
         Answer answer = question.getAnswers().get(request.getAnswerId());
 
         if (answer.isDecisive()) { // 진단 결과 안내
+            if (question.getId() == 332 & answer.getAnswerId() == 1 & request.getUnknownEmergency() == 1) { // 원인 불명의 안과질환 판별
+                return PrimaryHeadacheNextResponse.builder().type(2).result(new PrimaryHeadacheNextResponse.Result(1033, "원인 불명의 안과질환")).build();
+            }
             return PrimaryHeadacheNextResponse.builder().type(2).result(new PrimaryHeadacheNextResponse.Result(answer.getResultId(), answer.getResult())).build();
         }
         else { // 다음 질문

--- a/src/main/java/com/healthier/diagnosis/service/HeadacheQuestionService.java
+++ b/src/main/java/com/healthier/diagnosis/service/HeadacheQuestionService.java
@@ -254,6 +254,16 @@ public class HeadacheQuestionService {
         if (!answer.isDecisive()) {
             int nextQuestionId = answer.getNextQuestionId(); //다음 질문 id
 
+            // type 4: 일차성 두통 감별로직 공통질문 요청
+            if (nextQuestionId == 0) {
+                int unknownEmergency = 0;
+
+                if (questionId == 406 & answerId == 0) { // 원인 불명의 안과질환 가능성 판별
+                    unknownEmergency = 1;
+                }
+                return new HeadachePainAreaNextResponse(4, "일차성 두통 감별로직 공통질문을 요청하세요", unknownEmergency);
+            }
+
             // type 3: 통증 수치 질문
             if (Arrays.stream(PAIN_LEVEL_CHECK_QUESTION).anyMatch(i -> i == nextQuestionId)) {
                 return new HeadachePainAreaNextResponse(3, questionRepository.findById(nextQuestionId).get());

--- a/src/main/java/com/healthier/diagnosis/service/HeadacheQuestionService.java
+++ b/src/main/java/com/healthier/diagnosis/service/HeadacheQuestionService.java
@@ -70,6 +70,13 @@ public class HeadacheQuestionService {
     }
 
     /**
+     * 일차성 두통 감별로직 공통질문
+     */
+    public List<Question> getPrimaryHeadacheQuestion() {
+        return questionRepository.findByType(Type.PRIMARYHEADACHEC.label());
+    }
+
+    /**
      * 일차성 두통 공통 질문 결과
      *
      * [일차성 두통 공통 질문 점수 계산 로직]


### PR DESCRIPTION
일차성 두통 감별로직 공통질문 API 추가하였습니다.
</br>

원인 불명의 응급 안과 질환과 같은 예외 케이스를 다루기 위해 아래와 같은 변수값을 생성했습니다.
### unknownEmergency
  - 0 (예외 케이스 없음, 기본값)
  - 1 (예외 케이스 있음)
</br>

위 변수의 영향으로 아래 두가지 API 또한 이에 맞게 수정하였습니다.
- 일차성 두통 공통 질문 응답 API
   - (question.getId() == 332 & answer.getAnswerId() == 1 & request.getUnknownEmergency() == 1)의 경우
   - **원인 불명의 안과질환** 을 진단결과로 리턴한다.
- 특정 통증 부위 다음 질문 조회 API 
   - (questionId == 406 & answerId == 0) 경우
   - unknownEmergency = 1(TRUE)로 리턴한다.