### PR TITLE
Feature/ 두통 진단 결과 상세 API

### DIFF
--- a/src/main/java/com/healthier/diagnosis/controller/DiagnosisController.java
+++ b/src/main/java/com/healthier/diagnosis/controller/DiagnosisController.java
@@ -7,14 +7,18 @@ import org.springframework.web.bind.annotation.*;
 
 @CrossOrigin
 @RequiredArgsConstructor
-@RequestMapping(value="/api/diagnosis")
+@RequestMapping(value="/api")
 @RestController
 public class DiagnosisController {
     private final DiagnosisService diagnosisService;
 
-    @GetMapping(value = "/results/{id}")
+    @GetMapping(value = "/diagnosis/results/{id}")
     public ResponseEntity<?> getDiagnosis(@PathVariable String id) {
         return ResponseEntity.ok(diagnosisService.findDiagnosis(id));
     }
 
+    @GetMapping(value = "/v2/diagnose/headache/results/{id}")
+    public ResponseEntity<?> getHeadacheDiagnosisResultDetail(@PathVariable int id) {
+        return ResponseEntity.ok(diagnosisService.getHeadacheResultDetail(id));
+    }
 }

--- a/src/main/java/com/healthier/diagnosis/dto/headache/result/ResultDetail.java
+++ b/src/main/java/com/healthier/diagnosis/dto/headache/result/ResultDetail.java
@@ -1,0 +1,16 @@
+package com.healthier.diagnosis.dto.headache.result;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ResultDetail {
+    private int isResult;
+    private ResultDetailDto diagnosticResult;
+}

--- a/src/main/java/com/healthier/diagnosis/dto/headache/result/ResultDetailDto.java
+++ b/src/main/java/com/healthier/diagnosis/dto/headache/result/ResultDetailDto.java
@@ -1,0 +1,45 @@
+package com.healthier.diagnosis.dto.headache.result;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.healthier.diagnosis.domain.diagnosis.*;
+import lombok.Getter;
+import lombok.Setter;
+import java.util.ArrayList;
+
+@Getter
+@Setter
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ResultDetailDto {
+    private int id;
+    private String illustration;
+    private String h1;
+    private String title;
+    private ArrayList<String> h2;
+    private int severity;
+    private Explanation explanation;
+    private Cause cause;
+    private ArrayList<Solution> solutions;
+    private int medicineFlag;
+    private ArrayList<Medicine> medicines;
+    private ArrayList<Treatment> treatments;
+    private String bannerIllustration;
+
+    protected  ResultDetailDto() { }
+
+    public ResultDetailDto(Diagnosis diagnosis) {
+        id = diagnosis.getNewId();
+        illustration = diagnosis.getIllustration();
+        h1 = diagnosis.getH1();
+        title = diagnosis.getTitle();
+        h2 = diagnosis.getH2();
+        severity = diagnosis.getSeverity();
+        explanation = diagnosis.getExplanation();
+        cause = diagnosis.getCause();
+        solutions = diagnosis.getSolutions();
+        medicineFlag = diagnosis.getMedicineFlag();
+        medicines = diagnosis.getMedicines();
+        treatments = diagnosis.getTreatments();
+        bannerIllustration = diagnosis.getBannerIllustration();
+    }
+}

--- a/src/main/java/com/healthier/diagnosis/exception/CustomException.java
+++ b/src/main/java/com/healthier/diagnosis/exception/CustomException.java
@@ -1,10 +1,14 @@
 package com.healthier.diagnosis.exception;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class CustomException extends RuntimeException{
     private final ErrorCode errorCode;
+
+    // 예외 발생 원인(예외 메시지)을 전달하기 위해 String 타입의 매개변수를 갖는 생성자
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
 }

--- a/src/main/java/com/healthier/diagnosis/service/DiagnosisService.java
+++ b/src/main/java/com/healthier/diagnosis/service/DiagnosisService.java
@@ -5,10 +5,7 @@ import com.healthier.diagnosis.domain.log.Log;
 import com.healthier.diagnosis.domain.user.Track;
 import com.healthier.diagnosis.dto.DiagnosisResponseDto;
 import com.healthier.diagnosis.dto.headache.ResultDto;
-import com.healthier.diagnosis.dto.headache.result.HeadacheResult;
-import com.healthier.diagnosis.dto.headache.result.HeadacheResultDto;
-import com.healthier.diagnosis.dto.headache.result.HeadacheResultRequest;
-import com.healthier.diagnosis.dto.headache.result.HeadacheResultResponse;
+import com.healthier.diagnosis.dto.headache.result.*;
 import com.healthier.diagnosis.exception.CustomException;
 import com.healthier.diagnosis.exception.ErrorCode;
 import com.healthier.diagnosis.repository.DiagnosisLogRepository;
@@ -242,4 +239,17 @@ public class DiagnosisService {
         }
     }
 
+
+    /**
+     * 두통 진단 결과 상세 조회
+     */
+    public ResultDetail getHeadacheResultDetail(int resultId) {
+        Diagnosis diagnosis = diagnosisRepository.findByNewId(resultId)
+                .orElseThrow(()-> new CustomException(ErrorCode.DIAGNOSIS_NOT_FOUND));
+
+        return ResultDetail.builder()
+                .isResult(1)
+                .diagnosticResult(new ResultDetailDto(diagnosis))
+                .build();
+    }
 }

--- a/src/test/java/com/healthier/diagnosis/controller/DiagnosisControllerTest.java
+++ b/src/test/java/com/healthier/diagnosis/controller/DiagnosisControllerTest.java
@@ -11,7 +11,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -34,6 +33,14 @@ class DiagnosisControllerTest {
     void getDiagnosis() throws Exception{
         mockMvc.perform(MockMvcRequestBuilders.get("/api/diagnosis/results/62cd703fe49face142d9cffe").contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.diagnostic_result.id").value("62cd703fe49face142d9cffe"))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("두통 진단 결과 상세")
+    @Test
+    public void getHeadacheDiagnosisResultDetail() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v2/diagnose/headache/results/1025").contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.diagnostic_result.id").value(1025))
                 .andExpect(status().isOk());
     }
 }

--- a/src/test/java/com/healthier/diagnosis/service/DiagnosisServiceTest.java
+++ b/src/test/java/com/healthier/diagnosis/service/DiagnosisServiceTest.java
@@ -3,6 +3,8 @@ package com.healthier.diagnosis.service;
 import com.healthier.diagnosis.dto.DiagnosisResponseDto;
 import com.healthier.diagnosis.dto.headache.ResultDto;
 import com.healthier.diagnosis.dto.headache.result.HeadacheResultResponse;
+import com.healthier.diagnosis.dto.headache.result.ResultDetail;
+import com.healthier.diagnosis.exception.CustomException;
 import com.healthier.diagnosis.repository.DiagnosisRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -14,6 +16,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 class DiagnosisServiceTest {
@@ -103,5 +107,30 @@ class DiagnosisServiceTest {
         //thens
         Assertions.assertThat(resultPriority.getResults().getSuspicious().get(0).getContent()).isEqualTo("대후두 신경통");
         Assertions.assertThat(resultPriority.getResults().getPredicted().get(0).getContent()).isEqualTo("약물 과용으로 인한 두통");
+    }
+
+    @DisplayName("두통 진단 결과 상세 조회- O")
+    @Test
+    public void getHeadacheResultDetailTest1() throws Exception {
+        //given
+        int resultId = 1025;
+
+        //when
+        ResultDetail headacheResultDetail = diagnosisService.getHeadacheResultDetail(resultId);
+
+        //then
+        Assertions.assertThat(headacheResultDetail.getDiagnosticResult().getId()).isEqualTo(1025);
+    }
+
+    @DisplayName("두통 진단 결과 상세 조회- X 존재하지 않는 경우")
+    @Test
+    public void getHeadacheResultDetailTest2() throws Exception {
+        //given
+        int resultId = 2025;
+
+        //when
+        Throwable exception = assertThrows(CustomException.class, () -> diagnosisService.getHeadacheResultDetail(resultId));
+
+        assertEquals(exception.getMessage(), "해당 진단 정보를 찾을 수 없습니다.");
     }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- feature/14-headache-result -> dev

### 변경 사항
- **두통 진단 결과 상세 API** 기능을 추가했습니다.
-  테스트 : 존재 하는 결과 (약물 과용 두통), 존재 하지 않는 결과
- CustomException 에서 예외 발생 원인(예외 메시지)을 전달하기 위해 생성자를 수정했습니다.
- **_TODO : 수면장애 진단 결과 상세 API 에서 Response 를 domain Diagnosis가 아닌 ResultDetail 로 수정_**